### PR TITLE
Add ability to stream response to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ node_modules
 
 oclif.manifest.json
 oclif.lock
+
+coverage
+.nyc_output

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -2,9 +2,9 @@
   {
     "command": "org:api",
     "plugin": "@cristiand391/sf-plugin-api",
-    "flags": ["body", "header", "include", "method", "target-org"],
+    "flags": ["body", "header", "include", "method", "target-org", "stream-to-file"],
     "alias": [],
-    "flagChars": ["H", "X", "i", "o"],
+    "flagChars": ["H", "X", "i", "o", "S"],
     "flagAliases": []
   }
 ]


### PR DESCRIPTION
### What does this PR do?
- Adds a stream to file flag and behavior
- Allows an empty `body` (similar to `curl`)
- Splits headers on the first `:`. This allows for `:`s to exist in the header value

Note: "ignore whitespace" will make the diff cleaner

#### Testing 
You can test this by running a report and accepting an xlxs file ([api docs](https://developer.salesforce.com/docs/atlas.en-us.api_analytics.meta/api_analytics/sforce_analytics_rest_api_download_excel.htm))

Example command would be:
`sf org api '/services/data/v61.0/analytics/reports/00OEE000001ZdM52AK' -o gus -X POST -H "Accept:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" --body "" -S "report.xlsx"`

Confirm the file opens in Excel, Numbers, Google Sheets, etc

### What issues does this PR fix or reference?
[@W-16215223@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16215223)